### PR TITLE
Always use /clients endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,15 +14,15 @@ func (s *Sensu) GetClientsSlice(limit int, offset int) ([]interface{}, error) {
 
 // GetClient Return client info
 func (s *Sensu) GetClient(client string) (map[string]interface{}, error) {
-	return s.Get(fmt.Sprintf("client/%s", client))
+	return s.Get(fmt.Sprintf("clients/%s", client))
 }
 
 // GetClientHistory Return client history
 func (s *Sensu) GetClientHistory(client string) ([]interface{}, error) {
-	return s.GetList(fmt.Sprintf("client/%s/history", client), 0, 0)
+	return s.GetList(fmt.Sprintf("clients/%s/history", client), 0, 0)
 }
 
 // DeleteClient Return the list of clients
 func (s *Sensu) DeleteClient(client string) (map[string]interface{}, error) {
-	return s.Delete(fmt.Sprintf("client/%s", client))
+	return s.Delete(fmt.Sprintf("clients/%s", client))
 }


### PR DESCRIPTION
According to sensu docs, the API endpoint is clients (plural) even for retrieving a single client.
