### PR TITLE
Delete functions should only return an error

### DIFF
--- a/aggregates.go
+++ b/aggregates.go
@@ -26,6 +26,6 @@ func (s *Sensu) GetAggregateIssued(check string, issued string, summarize bool, 
 }
 
 // DeleteAggregate Return the list of Aggregates
-func (s *Sensu) DeleteAggregate(aggregate string) (map[string]interface{}, error) {
+func (s *Sensu) DeleteAggregate(aggregate string) error {
 	return s.Delete(fmt.Sprintf("aggregate/%s", aggregate))
 }

--- a/client.go
+++ b/client.go
@@ -23,6 +23,6 @@ func (s *Sensu) GetClientHistory(client string) ([]interface{}, error) {
 }
 
 // DeleteClient Return the list of clients
-func (s *Sensu) DeleteClient(client string) (map[string]interface{}, error) {
+func (s *Sensu) DeleteClient(client string) error {
 	return s.Delete(fmt.Sprintf("clients/%s", client))
 }

--- a/sensu.go
+++ b/sensu.go
@@ -164,29 +164,25 @@ func (s *Sensu) PostPayload(endpoint string, payload string) (map[string]interfa
 }
 
 // Delete resource
-func (s *Sensu) Delete(endpoint string) (map[string]interface{}, error) {
+func (s *Sensu) Delete(endpoint string) error {
 	url := fmt.Sprintf("%s/%s", s.URL, endpoint)
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Parsing error: %q returned: %v", err, err)
+		return fmt.Errorf("Parsing error: %q returned: %v", err, err)
 	}
 
 	res, err := http.DefaultClient.Do(req)
+	defer res.Body.Close()
 	if err != nil {
-		return nil, fmt.Errorf("API call to %q returned: %v", url, err)
+		return fmt.Errorf("API call to %q returned: %v", url, err)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return fmt.Errorf("%v", err)
 	}
 	if res.StatusCode >= 400 {
-		return nil, fmt.Errorf("%v", res.Status)
+		return fmt.Errorf("%v", res.Status)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
-	res.Body.Close()
-	if err != nil {
-		return nil, fmt.Errorf("Parsing response body returned: %v", err)
-	}
-	return s.doJSON(body)
+	return nil
 }

--- a/stashes.go
+++ b/stashes.go
@@ -47,6 +47,6 @@ func (s *Sensu) CreateStashPath(path string, payload map[string]interface{}) (ma
 }
 
 // DeleteStash Delete a stash (JSON document)
-func (s *Sensu) DeleteStash(path string) (map[string]interface{}, error) {
+func (s *Sensu) DeleteStash(path string) error {
 	return s.Delete(fmt.Sprintf("stashes/%s", path))
 }


### PR DESCRIPTION
Since Sensu does not return anything within the body of a DELETE request, we do not need to parse and return the body.
