### PR TITLE
Check the error before closing the res.Body

### DIFF
--- a/sensu.go
+++ b/sensu.go
@@ -210,10 +210,11 @@ func (s *Sensu) delete(endpoint string) error {
 	}
 
 	res, err := http.DefaultClient.Do(req)
-	defer res.Body.Close()
+
 	if err != nil {
 		return fmt.Errorf("API call to %q returned: %v", url, err)
 	}
+	defer res.Body.Close()
 
 	if err != nil {
 		return fmt.Errorf("%v", err)


### PR DESCRIPTION
See http://stackoverflow.com/questions/16280176/go-panic-runtime-error-invalid-memory-address-or-nil-pointer-dereference
